### PR TITLE
return content-type for getOutput/getExport/getTexture

### DIFF
--- a/packages/sdk.geometry-api-sdk-v2/package.json
+++ b/packages/sdk.geometry-api-sdk-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapediver/sdk.geometry-api-sdk-v2",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "SDK to communicate with the Geometry API version 2",
   "keywords": [
     "shapediver",

--- a/packages/sdk.geometry-api-sdk-v2/src/resources/ShapeDiverAssetApi.ts
+++ b/packages/sdk.geometry-api-sdk-v2/src/resources/ShapeDiverAssetApi.ts
@@ -13,13 +13,15 @@ export class ShapeDiverAssetApi extends BaseResourceApi {
      * @param sessionId
      * @param assetData
      */
-    async getExport (sessionId: string, assetData: string): Promise<ArrayBuffer> {
-        return await sendRequest(async () =>
-            (await this.api.get<ArrayBuffer>(
+    async getExport (sessionId: string, assetData: string): Promise<[ ArrayBuffer, string ]> {
+        return await sendRequest(async () => {
+            const [ header, data ] = await this.api.get<ArrayBuffer>(
                 `${ this.buildSessionUri(sessionId) }/export/${ assetData }`,
                 { responseType: ShapeDiverSdkApiResponseType.DATA },
-            ))[1],
-        )
+            )
+            const contentType = header["Content-Type"] ?? header["content-type"]
+            return [ data, contentType ]
+        })
     }
 
     /**
@@ -28,13 +30,15 @@ export class ShapeDiverAssetApi extends BaseResourceApi {
      * @param sessionId
      * @param assetData
      */
-    async getOutput (sessionId: string, assetData: string): Promise<ArrayBuffer> {
-        return await sendRequest(async () =>
-            (await this.api.get<ArrayBuffer>(
+    async getOutput (sessionId: string, assetData: string): Promise<[ ArrayBuffer, string ]> {
+        return await sendRequest(async () => {
+            const [ header, data ] = await this.api.get<ArrayBuffer>(
                 `${ this.buildSessionUri(sessionId) }/output/${ assetData }`,
                 { responseType: ShapeDiverSdkApiResponseType.DATA },
-            ))[1],
-        )
+            )
+            const contentType = header["Content-Type"] ?? header["content-type"]
+            return [ data, contentType ]
+        })
     }
 
     /**
@@ -61,13 +65,15 @@ export class ShapeDiverAssetApi extends BaseResourceApi {
      * @param sessionId
      * @param assetData
      */
-    async getTexture (sessionId: string, assetData: string): Promise<ArrayBuffer> {
-        return await sendRequest(async () =>
-            (await this.api.get<ArrayBuffer>(
+    async getTexture (sessionId: string, assetData: string): Promise<[ ArrayBuffer, string ]> {
+        return await sendRequest(async () => {
+            const [ header, data ] = await this.api.get<ArrayBuffer>(
                 `${ this.buildSessionUri(sessionId) }/texture/${ assetData }`,
                 { responseType: ShapeDiverSdkApiResponseType.DATA },
-            ))[1],
-        )
+            )
+            const contentType = header["Content-Type"] ?? header["content-type"]
+            return [ data, contentType ]
+        })
     }
 
     /**


### PR DESCRIPTION
@matthiasreisacher @MajorMeerkatThe3rd 
This PR extends the return value of getOutput, getExport, getTexture by content type, as mentioned here: https://github.com/shapediver/Viewer/pull/36#issue-1284942008

These two PRs can be considered a good working fix for the problem described here: https://shapediver.atlassian.net/browse/SS-5374
However I invited you to a meeting on Tuesday to discuss which improvements and clarifications to do in the SDK. 
I will merge this right away and publish as version 1.0.24: https://github.com/shapediver/GeometryBackendSdkTypeScript/packages/603216?version=1.0.24