### PR TITLE
SS-6589: G. Backend: TypeScript error handling improvements

### DIFF
--- a/libs/sdk.geometry-api-sdk-core/src/ShapeDiverErrors.ts
+++ b/libs/sdk.geometry-api-sdk-core/src/ShapeDiverErrors.ts
@@ -1,6 +1,15 @@
+export const ShapeDiverErrorType = {
+    Generic: "sd_gb_sdk_generic",
+    Request: "sd_gb_sdk_request",
+    Response: "sd_gb_sdk_response",
+} as const
+export type ShapeDiverErrorType = typeof ShapeDiverErrorType[keyof typeof ShapeDiverErrorType]
+
 export class ShapeDiverError extends Error {
 
-    constructor (message: string) {
+    public readonly errorType: ShapeDiverErrorType = ShapeDiverErrorType.Generic
+
+    constructor(message: string) {
         super(message)
     }
 
@@ -8,7 +17,9 @@ export class ShapeDiverError extends Error {
 
 export class ShapeDiverRequestError extends ShapeDiverError {
 
-    constructor (
+    public readonly errorType: ShapeDiverErrorType = ShapeDiverErrorType.Request
+
+    constructor(
         public readonly desc: string,
         message: string,
     ) {
@@ -19,7 +30,9 @@ export class ShapeDiverRequestError extends ShapeDiverError {
 
 export class ShapeDiverResponseError extends ShapeDiverError {
 
-    constructor (
+    public readonly errorType: ShapeDiverErrorType = ShapeDiverErrorType.Response
+
+    constructor(
         message: string,
         public readonly status: number,
         public readonly error: string,

--- a/libs/sdk.geometry-api-sdk-core/src/index.ts
+++ b/libs/sdk.geometry-api-sdk-core/src/index.ts
@@ -1,13 +1,23 @@
-import { ShapeDiverSdkApi, ShapeDiverSdkApiRequestOptions, ShapeDiverSdkApiResponseType } from "./api/ShapeDiverSdkApi"
+import {
+    ShapeDiverSdkApi,
+    ShapeDiverSdkApiRequestOptions,
+    ShapeDiverSdkApiResponseType,
+} from "./api/ShapeDiverSdkApi"
 import { BaseShapeDiverSdk } from "./BaseShapeDiverSdk"
 import { ShapeDiverSdkConfig, ShapeDiverSdkConfigType } from "./config/ShapeDiverSdkConfig"
 import { BaseResourceApi } from "./resources/BaseResourceApi"
-import { ShapeDiverError, ShapeDiverRequestError, ShapeDiverResponseError } from "./ShapeDiverErrors"
+import {
+    ShapeDiverError,
+    ShapeDiverErrorType,
+    ShapeDiverRequestError,
+    ShapeDiverResponseError,
+} from "./ShapeDiverErrors"
 
 export {
     BaseResourceApi,
     BaseShapeDiverSdk,
     ShapeDiverError,
+    ShapeDiverErrorType,
     ShapeDiverRequestError,
     ShapeDiverResponseError,
     ShapeDiverSdkApi,

--- a/packages/sdk.geometry-api-sdk-v2/README.md
+++ b/packages/sdk.geometry-api-sdk-v2/README.md
@@ -70,6 +70,42 @@ import { create } from "@shapediver/sdk.geometry-api-sdk-v2"
 })()
 ```
 
+## Handling Errors
+The SDK provides type guards to distinguish between error types.
+
+```
+import {
+  isGBError,
+  isGBGenericError,
+  isGBRequestError,
+  isGBResponseError,
+} from "@shapediver/sdk.geometry-api-sdk-v2"
+
+try {
+  sdk.model.get("be5d4ce5-f76d-417d-8496-1f038e6f0cab")
+catch (e: any) {
+  if (isGBRequestError(e)) {
+    // e is a request error.
+    // In this case, the request was made but no response was received.
+  }
+
+  if (isGBResponseError(e)) {
+    // e is a response error.
+    // In this case, the request was made and the server responded with a status code that falls
+    // out of the range of 2xx.
+  }
+
+  if (isGBGenericError(e)) {
+    // e is a generic error.
+    // Generic errors are used for everything that is neither a request error nor a response error.
+  }
+
+  if (isGBError(e)) {
+    // e is either a generic error, request error or response error.
+  }
+}
+```
+
 ## Examples
 Some practical use cases, we will regularly extend the list: 
 

--- a/packages/sdk.geometry-api-sdk-v2/__tests__/utils.test.ts
+++ b/packages/sdk.geometry-api-sdk-v2/__tests__/utils.test.ts
@@ -1,9 +1,108 @@
-import { ShapeDiverResponseError } from "@shapediver/sdk.geometry-api-sdk-core"
+import {
+    ShapeDiverError as ShapeDiverErrorCore,
+    ShapeDiverRequestError as ShapeDiverRequestErrorCore,
+    ShapeDiverResponseError as ShapeDiverResponseErrorCore,
+} from "@shapediver/sdk.geometry-api-sdk-core"
+import {
+    ShapeDiverResponseError,
+    isGBError,
+    isGBGenericError,
+    isGBRequestError,
+    isGBResponseError,
+} from ".."
 
 // @ts-ignore
 import { sendRequest } from "../src/utils/utils"
 
-describe("utils - sendRequest", () => {
+describe("isGBError", () => {
+
+    test.each([
+        ["ShapeDiverErrorCore", new ShapeDiverErrorCore("")],
+        ["ShapeDiverRequestErrorCore", new ShapeDiverRequestErrorCore("", "")],
+        ["ShapeDiverResponseErrorCore", new ShapeDiverResponseErrorCore("", -1, "", "", {})],
+        ["ShapeDiverResponseError", new ShapeDiverResponseError(
+            new ShapeDiverResponseErrorCore("", -1, "", "", {}),
+        )],
+    ])("%s; should be truthy", (_, error) => {
+        expect(isGBError(error)).toBeTruthy()
+    })
+
+    test.each([
+        ["object", { message: "" }],
+        ["JS-error", new Error("")],
+    ])("should be falsy", (_, error) => {
+        expect(isGBError(error)).toBeFalsy()
+    })
+
+})
+
+describe("isGBGenericError", () => {
+
+    test.each([
+        ["ShapeDiverErrorCore", new ShapeDiverErrorCore("")],
+    ])("%s; should be truthy", (_, error) => {
+        expect(isGBGenericError(error)).toBeTruthy()
+    })
+
+    test.each([
+        ["object", { message: "" }],
+        ["JS-error", new Error("")],
+        ["ShapeDiverRequestErrorCore", new ShapeDiverRequestErrorCore("", "")],
+        ["ShapeDiverResponseErrorCore", new ShapeDiverResponseErrorCore("", -1, "", "", {})],
+        ["ShapeDiverResponseError", new ShapeDiverResponseError(
+            new ShapeDiverResponseErrorCore("", -1, "", "", {}),
+        )],
+    ])("%s; should be falsy", (_, error) => {
+        expect(isGBGenericError(error)).toBeFalsy()
+    })
+
+})
+
+describe("isGBRequestError", () => {
+
+    test.each([
+        ["ShapeDiverRequestErrorCore", new ShapeDiverRequestErrorCore("", "")],
+    ])("%s; should be truthy", (_, error) => {
+        expect(isGBRequestError(error)).toBeTruthy()
+    })
+
+    test.each([
+        ["object", { message: "" }],
+        ["JS-error", new Error("")],
+        ["ShapeDiverErrorCore", new ShapeDiverErrorCore("")],
+        ["ShapeDiverResponseErrorCore", new ShapeDiverResponseErrorCore("", -1, "", "", {})],
+        ["ShapeDiverResponseError", new ShapeDiverResponseError(
+            new ShapeDiverResponseErrorCore("", -1, "", "", {}),
+        )],
+    ])("%s; should be falsy", (_, error) => {
+        expect(isGBRequestError(error)).toBeFalsy()
+    })
+
+})
+
+describe("isGBResponseError", () => {
+
+    test.each([
+        ["ShapeDiverResponseErrorCore", new ShapeDiverResponseErrorCore("", -1, "", "", {})],
+        ["ShapeDiverResponseError", new ShapeDiverResponseError(
+            new ShapeDiverResponseErrorCore("", -1, "", "", {}),
+        )],
+    ])("%s; should be truthy", (_, error) => {
+        expect(isGBResponseError(error)).toBeTruthy()
+    })
+
+    test.each([
+        ["object", { message: "" }],
+        ["JS-error", new Error("")],
+        ["ShapeDiverErrorCore", new ShapeDiverErrorCore("")],
+        ["ShapeDiverRequestErrorCore", new ShapeDiverRequestErrorCore("", "")],
+    ])("%s; should be falsy", (_, error) => {
+        expect(isGBResponseError(error)).toBeFalsy()
+    })
+
+})
+
+describe("sendRequest", () => {
 
     let spyCall: number
     let call = (e?: Error): Promise<string> => {
@@ -25,20 +124,29 @@ describe("utils - sendRequest", () => {
         await expect(async () => await sendRequest(call.bind(null, new Error("intended error"))))
             .rejects
             .toThrow()
+
         expect(spyCall).toBe(1)
     })
 
     test("managed error - 429; should throw", async () => {
-        await expect(async () => await sendRequest(call.bind(null, new ShapeDiverResponseError("", 429, "", "", { "retry-after": 1 }))))
+        await expect(async () => await sendRequest(call.bind(
+            null,
+            new ShapeDiverResponseErrorCore("", 429, "", "", { "retry-after": 1 }),
+        )))
             .rejects
             .toThrow()
+
         expect(spyCall).toBe(5)
     })
 
     test("managed error - 502; should throw", async () => {
-        await expect(async () => await sendRequest(call.bind(null, new ShapeDiverResponseError("", 502, "", "", { "retry-after": 1 }))))
+        await expect(async () => await sendRequest(call.bind(
+            null,
+            new ShapeDiverResponseErrorCore("", 502, "", "", { "retry-after": 1 }),
+        )))
             .rejects
             .toThrow()
+
         expect(spyCall).toBe(5)
     })
 

--- a/packages/sdk.geometry-api-sdk-v2/src/ShapeDiverErrors.ts
+++ b/packages/sdk.geometry-api-sdk-v2/src/ShapeDiverErrors.ts
@@ -4,17 +4,22 @@ import {
 } from "@shapediver/api.geometry-api-dto-v2"
 import {
     ShapeDiverError,
+    ShapeDiverErrorType,
     ShapeDiverResponseError as ShapeDiverResponseErrorCore,
 } from "@shapediver/sdk.geometry-api-sdk-core"
 
 /* Replaces core/ShapeDiverErrors/ShapeDiverResponseError with DTOv2-types */
-export class ShapeDiverResponseError extends ShapeDiverError implements ShapeDiverResponseErrorDto {
+export class ShapeDiverResponseError
+    extends ShapeDiverError
+    implements ShapeDiverResponseErrorDto {
+
+    public readonly errorType: ShapeDiverErrorType = ShapeDiverErrorType.Response
 
     public readonly status: number
     public readonly error: ShapeDiverResponseErrorType
     public readonly desc: string
 
-    constructor (e: ShapeDiverResponseErrorCore) {
+    constructor(e: ShapeDiverResponseErrorCore) {
         super(e.message)
 
         this.status = e.status

--- a/packages/sdk.geometry-api-sdk-v2/src/index.ts
+++ b/packages/sdk.geometry-api-sdk-v2/src/index.ts
@@ -8,3 +8,9 @@ export {
 } from "@shapediver/sdk.geometry-api-sdk-core"
 export { ShapeDiverResponseError } from "./ShapeDiverErrors"
 export { create, ShapeDiverSdk } from "./ShapeDiverSdk"
+export {
+    isGBError,
+    isGBGenericError,
+    isGBRequestError,
+    isGBResponseError,
+} from "./utils/utils"

--- a/packages/sdk.geometry-api-sdk-v2/src/utils/utils.ts
+++ b/packages/sdk.geometry-api-sdk-v2/src/utils/utils.ts
@@ -1,14 +1,45 @@
 import {
     ShapeDiverError,
+    ShapeDiverErrorType,
+    ShapeDiverRequestError as ShapeDiverRequestErrorCore,
     ShapeDiverResponseError as ShapeDiverResponseErrorCore,
 } from "@shapediver/sdk.geometry-api-sdk-core"
 import { ShapeDiverResponseError } from "../ShapeDiverErrors"
+
+/** Type guard for all error types of the Geometry Backend SDK package. */
+export function isGBError(e: any): e is
+    (ShapeDiverError & ShapeDiverRequestErrorCore & ShapeDiverResponseError) {
+    return e instanceof Error &&
+        "errorType" in e &&
+        Object.values(ShapeDiverErrorType).includes(e.errorType as any)
+}
+
+/** Type guard for a Geometry Backend SDK generic error. */
+export function isGBGenericError(e: any): e is ShapeDiverError {
+    return e instanceof Error &&
+        "errorType" in e &&
+        e.errorType === ShapeDiverErrorType.Generic
+}
+
+/** Type guard for a Geometry Backend SDK request error. */
+export function isGBRequestError(e: any): e is ShapeDiverRequestErrorCore {
+    return e instanceof Error &&
+        "errorType" in e &&
+        e.errorType === ShapeDiverErrorType.Request
+}
+
+/** Type guard for a Geometry Backend SDK response error. */
+export function isGBResponseError(e: any): e is ShapeDiverResponseError {
+    return e instanceof Error &&
+        "errorType" in e &&
+        e.errorType === ShapeDiverErrorType.Response
+}
 
 /**
  * Sends the given request, handles retries for the HTTP status 429, and maps
  * the response error object to its typed representation.
  */
-export async function sendRequest<T> (call: () => Promise<T>): Promise<T> {
+export async function sendRequest<T>(call: () => Promise<T>): Promise<T> {
     const retryLimit = 5
     let retryCounter = 0
 
@@ -44,12 +75,12 @@ export async function sendRequest<T> (call: () => Promise<T>): Promise<T> {
 }
 
 /** Delays the response for the given number of milliseconds */
-export function sleep (ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /** Encode the given string to base64 */
-export function encodeBase64 (str: string): string {
+export function encodeBase64(str: string): string {
     try {
         return btoa(str)
     } catch (err) {


### PR DESCRIPTION
[SS-6589](https://shapediver.atlassian.net/browse/SS-6589)

In this PR, the Geometry Backend SDK is extended by type guard functions that can be used to distinguish between all SDK errors. To prevent the usage of JavaScript's `instanceof` function, the SDK error classes have been extended by a string literal that is specific to this SDK.

The same concept has been applied to the following SDK packages:
* [TokenGeneratorSdkTypeScript](https://github.com/shapediver/TokenGeneratorSdkTypeScript/commit/8217f831f870f2de2f627eb05034c652b0ebc0ff)
* [ShapeDiverSdtfSdkTypeScript](https://github.com/shapediver/ShapeDiverSdtfTypeScript/commit/9120dd8cf8f9b6b3acf89dd510b522831a634e85)
* [StargateSdkTypeScript](https://github.com/shapediver/StargateSdkTypeScript/commit/ed3eabadf932ca9caa6c1425fb62812275a050e8)

@matthiasreisacher these changes have not been merged and published in any SDK package, which must be done when this PR has been approved!