### PR TITLE
SS-9566 Apply base config in util-downloads

### DIFF
--- a/packages/sdk.geometry-api-sdk-v2/__tests__/UtilsApi.test.ts
+++ b/packages/sdk.geometry-api-sdk-v2/__tests__/UtilsApi.test.ts
@@ -1,5 +1,6 @@
-import axios, { AxiosHeaders } from 'axios';
+import axios, { AxiosHeaders, RawAxiosRequestConfig } from 'axios';
 import {
+    Configuration,
     ExportApi,
     OutputApi,
     ResComputeExports,
@@ -11,6 +12,7 @@ import {
     TimeoutError,
     UtilsApi,
 } from '../src';
+import * as common from '../src/client/common';
 
 describe('Axios Response Types in Node.js', () => {
     const httpbin = 'https://httpbin.dev',
@@ -666,5 +668,254 @@ describe('getMaxExportDelay', function () {
             }
         );
         expect(res).toBe(-1);
+    });
+});
+
+describe('buildRequestOptions', function () {
+    const authHeader = 'Bearer mock-token',
+        url = 'https://example.com',
+        basePath = url;
+
+    // Wrapper around private utils function
+    function buildRequestOptions(utilsApi: UtilsApi, url: string, options: RawAxiosRequestConfig) {
+        return (utilsApi as any).buildRequestOptions(url, options);
+    }
+
+    // Helper to control whether isTargetingInternalOrNoCdnServer returns true or false
+    function mockIsTargeting(utilsApi: UtilsApi, returnValue: boolean) {
+        jest.spyOn(utilsApi as any, 'isTargetingInternalOrNoCdnServer').mockReturnValue(
+            returnValue
+        );
+    }
+
+    beforeEach(() => {
+        // Always sets the Authorization header when called
+        jest.spyOn(common, 'setBearerAuthToObject').mockImplementation(async (object: any) => {
+            object['Authorization'] = authHeader;
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('options, no auth; should merge them into result', async () => {
+        const utilsApi = new UtilsApi();
+        mockIsTargeting(utilsApi, false);
+
+        const result = await buildRequestOptions(utilsApi, url, {
+            timeout: 5000,
+        });
+        expect(result.timeout).toBe(5000);
+        expect(result.headers?.Authorization).toBeUndefined();
+    });
+
+    test('baseOptions, no auth; should merge them into result', async () => {
+        const utilsApi = new UtilsApi(
+            new Configuration({
+                basePath,
+                baseOptions: { timeout: 9999, headers: { 'X-Custom': 'base-value' } },
+            })
+        );
+        mockIsTargeting(utilsApi, false);
+
+        const result = await buildRequestOptions(utilsApi, url, {});
+        expect(result.timeout).toBe(9999);
+        expect(result.headers?.['X-Custom']).toBe('base-value');
+    });
+
+    test('baseOptions and options, no auth; options should override baseOptions headers', async () => {
+        const config = new Configuration({
+            basePath,
+            baseOptions: { headers: { 'X-Custom': 'base-value' } },
+        });
+        const utilsApi = new UtilsApi(config);
+        mockIsTargeting(utilsApi, false);
+
+        const result = await buildRequestOptions(utilsApi, url, {
+            headers: { 'X-Custom': 'override-value' },
+        });
+        expect(result.headers?.['X-Custom']).toBe('override-value');
+    });
+
+    test('auth; should set bearer auth header', async () => {
+        const config = new Configuration({ basePath });
+        const utilsApi = new UtilsApi(config);
+        mockIsTargeting(utilsApi, true);
+
+        const result = await buildRequestOptions(utilsApi, url, {});
+        expect(result.headers?.Authorization).toBe(authHeader);
+    });
+
+    test('auth and options-auth; options should override bearer auth header', async () => {
+        const config = new Configuration({ basePath });
+        const utilsApi = new UtilsApi(config);
+        mockIsTargeting(utilsApi, true);
+
+        const result = await buildRequestOptions(utilsApi, url, {
+            headers: { Authorization: 'Bearer override-token' },
+        });
+        expect(result.headers?.Authorization).toBe('Bearer override-token');
+    });
+});
+
+describe('isTargetingInternalOrNoCdnServer', function () {
+    // Wrapper around private utils function
+    function isTargetingInternalOrNoCdnServer(utilsApi: UtilsApi, url: string) {
+        return (utilsApi as any).isTargetingInternalOrNoCdnServer(url);
+    }
+
+    test('returns false when no configuration is set', () => {
+        const utilsApi = new UtilsApi();
+        expect(isTargetingInternalOrNoCdnServer(utilsApi, 'https://example.com')).toBeFalsy();
+    });
+
+    test('returns false when configuration has no basePath', () => {
+        const utilsApi = new UtilsApi(new Configuration({}));
+        expect(isTargetingInternalOrNoCdnServer(utilsApi, 'https://example.com')).toBeFalsy();
+    });
+
+    test('returns true when URL origin matches basePath origin', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(
+            isTargetingInternalOrNoCdnServer(
+                utilsApi,
+                'https://sddev2.eu-central-1.shapediver.com/api/v2/session'
+            )
+        ).toBeTruthy();
+    });
+
+    test('returns false when URL origin differs from basePath origin', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(
+            isTargetingInternalOrNoCdnServer(utilsApi, 'https://other-server.com/api/v2/session')
+        ).toBeFalsy();
+    });
+
+    test('returns true for ShapeDiver no-CDN URL', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(
+            isTargetingInternalOrNoCdnServer(
+                utilsApi,
+                'https://system-nocdn.eu-central-1.shapediver.com/session/abc'
+            )
+        ).toBeTruthy();
+    });
+
+    test('returns false for a URL that does not match no-CDN pattern', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(
+            isTargetingInternalOrNoCdnServer(
+                utilsApi,
+                'https://system-cdn.eu-central-1.shapediver.com/session/abc'
+            )
+        ).toBeFalsy();
+    });
+
+    test('returns false for an invalid URL', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(isTargetingInternalOrNoCdnServer(utilsApi, 'not-a-valid:::url')).toBeFalsy();
+    });
+
+    test('resolves relative URL against basePath and returns true for same origin', () => {
+        const config = new Configuration({
+            basePath: 'https://sddev2.eu-central-1.shapediver.com',
+        });
+        const utilsApi = new UtilsApi(config);
+        expect(isTargetingInternalOrNoCdnServer(utilsApi, '/api/v2/session/abc')).toBeTruthy();
+    });
+});
+
+describe('disableAuthHeaderForShapeDiverUris', function () {
+    const utilsApi = new UtilsApi();
+
+    // Wrapper around private utils function
+    function disableAuthHeaderForShapeDiverUris(url: string, options: RawAxiosRequestConfig) {
+        return (utilsApi as any).disableAuthHeaderForShapeDiverUris(url, options);
+    }
+
+    test('does nothing when Authorization header is already set', () => {
+        const options: RawAxiosRequestConfig = { headers: { Authorization: 'Bearer token123' } };
+        disableAuthHeaderForShapeDiverUris('https://viewer.shapediver.com/asset', options);
+        expect(options.headers!.Authorization).toBe('Bearer token123');
+    });
+
+    test('does nothing for an invalid URL', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris('not-a-valid:::url', options);
+        expect('Authorization' in options.headers!).toBe(false);
+    });
+
+    test('sets Authorization to undefined for viewer.shapediver.com', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris('https://viewer.shapediver.com/asset', options);
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('sets Authorization to undefined for textures.shapediver.com', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris('https://textures.shapediver.com/asset', options);
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('sets Authorization to undefined for downloads.shapediver.com', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris('https://downloads.shapediver.com/asset', options);
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('sets Authorization to undefined for CDN output URL', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris(
+            'https://cdn.shapediver.com/cdn-asset-outputs/abc123',
+            options
+        );
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('sets Authorization to undefined for CDN export URL', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris(
+            'https://cdn.shapediver.com/cdn-asset-exports/abc123',
+            options
+        );
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('sets Authorization to undefined for CDN texture URL', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris(
+            'https://cdn.shapediver.com/cdn-asset-textures/abc123',
+            options
+        );
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+    });
+
+    test('does nothing for non-ShapeDiver URL', () => {
+        const options: RawAxiosRequestConfig = { headers: {} };
+        disableAuthHeaderForShapeDiverUris('https://example.com/some/path', options);
+        expect('Authorization' in options.headers!).toBe(false);
+    });
+
+    test('preserves existing headers when disabling Authorization', () => {
+        const options: RawAxiosRequestConfig = { headers: { 'Content-Type': 'application/json' } };
+        disableAuthHeaderForShapeDiverUris('https://viewer.shapediver.com/asset', options);
+        expect(options.headers).toHaveProperty('Authorization', undefined);
+        expect(options.headers).toHaveProperty('Content-Type', 'application/json');
     });
 });

--- a/packages/sdk.geometry-api-sdk-v2/src/UtilsApi.ts
+++ b/packages/sdk.geometry-api-sdk-v2/src/UtilsApi.ts
@@ -16,7 +16,11 @@ import {
     ResOutput,
 } from './client';
 import { BaseAPI, RequestArgs } from './client/base';
-import { createRequestFunction, serializeDataIfNeeded } from './client/common';
+import {
+    createRequestFunction,
+    serializeDataIfNeeded,
+    setBearerAuthToObject,
+} from './client/common';
 import { IllegalArgumentError, ResponseError, TimeoutError } from './error';
 import { contentDispositionFromFilename, sleep } from './utils';
 
@@ -34,6 +38,9 @@ const cdnAssetTextureUri = /.+\/cdn-asset-textures\/.+/;
 /* Regex patterns for direct download URIs. */
 const directDownloadUri = /^(http[s]?:\/\/)?(viewer|textures|downloads)\.shapediver\.com(\/.*)?$/;
 
+/* Regex pattern for ShapeDiver no-CDN servers. */
+const sdNoCdnOrigin = /-nocdn.[\w-]+.shapediver.com$/;
+
 export class UtilsApi extends BaseAPI {
     constructor(configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
         super(configuration, basePath, axios);
@@ -41,6 +48,8 @@ export class UtilsApi extends BaseAPI {
 
     /**
      * Upload the given file to the specified URL.
+     *
+     * _Note: This method does not use the `UtilsApi`'s base configuration._
      * @param {string} url The target URL of the upload request.
      * @param {*} data The data that should be uploaded.
      * @param {string} contentType Indicate the original media type of the resource.
@@ -76,6 +85,8 @@ export class UtilsApi extends BaseAPI {
 
     /**
      * Upload the given asset to the specified ShapeDiver URL.
+     *
+     * _Note: This method does not use the `UtilsApi`'s base configuration._
      * @param {string} url The target URL of the upload request.
      * @param {*} data The data that should be uploaded.
      * @param {ResAssetUploadHeaders} headers The headers object that was returned from the request-upload call.
@@ -130,8 +141,11 @@ export class UtilsApi extends BaseAPI {
         options: { responseType: 'text' } & RawAxiosRequestConfig
     ): AxiosPromise<string>;
     public download(url: string, options?: RawAxiosRequestConfig): AxiosPromise<any>;
-    public download(url: string, options?: RawAxiosRequestConfig): AxiosPromise<any> {
-        const request = this.buildRequest('GET', url, undefined, options)();
+    public async download(url: string, options?: RawAxiosRequestConfig): AxiosPromise<any> {
+        const localRequestOptions = await this.buildRequestOptions(url, options ?? {});
+        this.disableAuthHeaderForShapeDiverUris(url, localRequestOptions);
+
+        const request = this.buildRequest('GET', url, undefined, localRequestOptions)();
         const res = request();
 
         // Convert Buffer to ArrayBuffer in Node.js when responseType is 'arraybuffer'
@@ -201,7 +215,6 @@ export class UtilsApi extends BaseAPI {
         options?: RawAxiosRequestConfig
     ): [AxiosPromise<any>, 'export' | 'output' | 'texture'] {
         let type: 'output' | 'export' | 'texture';
-        this.disableAuthHeaderForShapeDiverUris(url, options);
 
         // Check if the given URL is a valid API or CDN asset URL
         if (apiAssetExportUri.test(url) || cdnAssetExportUri.test(url)) type = 'export';
@@ -240,8 +253,6 @@ export class UtilsApi extends BaseAPI {
         url: string,
         options?: RawAxiosRequestConfig
     ): AxiosPromise<any> {
-        this.disableAuthHeaderForShapeDiverUris(url, options);
-
         if (
             apiAssetTextureUri.test(url) ||
             cdnAssetTextureUri.test(url) ||
@@ -250,7 +261,10 @@ export class UtilsApi extends BaseAPI {
             // Call ShapeDiver texture-asset URLs directly
             return this.download(url, options) as any;
         } else {
-            // All other source URLs are called via the download-image endpoint
+            /* All other source URLs are called via the download-image endpoint */
+
+            const localOptions: RawAxiosRequestConfig = options ?? {};
+            this.disableAuthHeaderForShapeDiverUris(url, localOptions);
 
             // Use a universal base64 encoder for browser and Node.js environments
             const encodedUrl =
@@ -262,7 +276,11 @@ export class UtilsApi extends BaseAPI {
                       )
                     : Buffer.from(url, 'utf-8').toString('base64');
 
-            return new AssetsApi(this.configuration).downloadImage(sessionId, encodedUrl, options);
+            return new AssetsApi(this.configuration).downloadImage(
+                sessionId,
+                encodedUrl,
+                localOptions
+            );
         }
     }
 
@@ -509,6 +527,58 @@ export class UtilsApi extends BaseAPI {
     }
 
     /**
+     * Builds the Axios request options by merging the API's base configuration with the given
+     * options, and conditionally setting or overrides the Authorization header.
+     *
+     * The authorization header is set, when the URL is targeting the same server as the one
+     * specified in the API's base path configuration, or if it is a ShapeDiver no-CDN server. In
+     * this case, the Bearer token from the API configuration will be used.
+     * @param url The URL to send the request to.
+     * @param options The Axios request options.
+     * @returns The merged Axios request options.
+     */
+    private async buildRequestOptions(
+        url: string,
+        options: RawAxiosRequestConfig
+    ): Promise<RawAxiosRequestConfig> {
+        let baseOptions;
+        if (this.configuration) baseOptions = this.configuration.baseOptions;
+
+        const localRequestOptions = { ...baseOptions, ...options },
+            localHeaderParameter = {} as any;
+
+        if (this.isTargetingInternalOrNoCdnServer(url))
+            await setBearerAuthToObject(localHeaderParameter, this.configuration);
+
+        let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+        localRequestOptions.headers = {
+            ...localHeaderParameter,
+            ...headersFromBaseOptions,
+            ...options.headers,
+        };
+
+        return localRequestOptions;
+    }
+
+    /**
+     * Checks whether the given URL is targeting the same server as the one specified in the API's
+     * base path configuration or if it is a ShapeDiver no-CDN server.
+     */
+    private isTargetingInternalOrNoCdnServer(url: string): boolean {
+        const basePath = this.configuration?.basePath;
+        if (!basePath) return false;
+
+        try {
+            const targetUrl = new URL(url, basePath);
+            const baseUrl = new URL(basePath);
+
+            return targetUrl.origin === baseUrl.origin || sdNoCdnOrigin.test(targetUrl.origin);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * A wrapper around the auto-generated `serializeDataIfNeeded` that safely serializes data for
      * Axios. The idea of the base function is to stringify objects for application-json requests.
      * However, this does not work on all data types. Thus, this wrapper passes through all data
@@ -547,15 +617,18 @@ export class UtilsApi extends BaseAPI {
     }
 
     /** Disable the Authorization header for ShapeDiver URIs if not explicitly set. */
-    private disableAuthHeaderForShapeDiverUris(
-        url: string,
-        options?: RawAxiosRequestConfig
-    ): void {
-        options = { ...options };
-        if (
-            !options.headers?.Authorization &&
-            (cdnAssetUri.test(url) || directDownloadUri.test(url))
-        )
+    private disableAuthHeaderForShapeDiverUris(url: string, options: RawAxiosRequestConfig): void {
+        // When an authorization header is set, it will override anything that is set later
+        if (options.headers?.Authorization) return;
+
+        let targetUrl: URL;
+        try {
+            targetUrl = new URL(url);
+        } catch {
+            return;
+        }
+
+        if (directDownloadUri.test(targetUrl.origin) || cdnAssetUri.test(url))
             options.headers = { Authorization: undefined, ...options.headers };
     }
 }


### PR DESCRIPTION
[Jira](https://shapediver.atlassian.net/browse/SS-9566)

We now attach the access token when provided when:
- the hostname matches the hostname of the base-config.
- the hostname matches a no-cdn ShapeDiver URL.

And we explicitly remove the access token (if not specified by the user) when:
- the URL is one of our CDN URLs.
- the URL targets on of our direct download URLs.